### PR TITLE
Clarify that only a single GitHub login can be connected to your GPT Engineer account.

### DIFF
--- a/src/features/git-integration.md
+++ b/src/features/git-integration.md
@@ -1,26 +1,27 @@
-# :simple-github: GitHub integration
+# :simple-github: GitHub Integration
 
+To make it easier for developers to work together with the AI on projects, gptengineer.app backs all projects with a git repository and lets you push commits directly to the repository.
 
-To make it easier for developers to work together with the AI on projects, gptengineer.app backs all projects with a git repository, and lets you push commits yourself directly to the repository.
-
-In order to push commits to the GitHub your project, and gptengineer.app will automatically pull them in and update the project. This allows you to make changes yourself, without asking the AI.
+In order to push commits to GitHub, your project and gptengineer.app will automatically pull them in and update the project. This allows you to make changes yourself, without asking the AI.
 
 ## Connecting a project to your GitHub account
 
-Before pushing your first commit, you will need to connect your GitHub account to the project. You can do this by navigating to the GitHub -> Create Repository -> Add another account. You will then be redirected to GitHub to authorize the connection.
+Before pushing your first commit, you will need to connect your GitHub account to the project. You can do this by navigating to GitHub -> Connect to GitHub. You will then be redirected to GitHub to authorize the connection.
 
-You can pick any option between granting access to (1) all repositories, or (2) specific repositories, as both will authorise is to create repositories in your GitHub account.
+You can choose to either granting access to (1) all repositories, or (2) specific repositories. Both options will let GPT Engineer create repositories in your GitHub account or organization.
+
+Note that you can only connect one GitHub login to your GPT Engineer account, but you can create repositories in any of the organizations you choose to install the GPT Engineer app in.
 
 <video autoplay loop src="/assets/connect-to-github.mp4"> video </video>
 
-Please note that you will need to have admin access if you are trying to create a repository in an organization.
+Please note that you will need admin access if you are trying to create a repository in an organization.
 
-## Making changes to a project through commits 
+## Making changes to a project through commits
 
-Once you have connected your GitHub account to your project, you can view the source code by navigating to the GitHub -> View on GitHub.
+Once you have connected your GitHub account to your project, you can view the source code by navigating to GitHub -> View on GitHub.
 
-Any change you make and push to the repository will be automatically reflected in the gptengineer.app.
+Any change you make and push to the repository will be automatically reflected in gptengineer.app.
 
-You commit changes directly in GitHub Codespaces or clone the repo to use your preferred IDE.
+You can commit changes directly in GitHub Codespaces or clone the repo to use your preferred IDE.
 
 <video autoplay loop src="/assets/sync-commits.mp4"> video </video>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clarifies GitHub login limitations and updates connection instructions in `git-integration.md`.
> 
>   - **Documentation Update**:
>     - Clarifies in `git-integration.md` that only one GitHub login can be connected to a GPT Engineer account.
>     - Updates instructions for connecting a GitHub account, specifying navigation to "GitHub -> Connect to GitHub".
>     - Explains repository access options and the requirement for admin access in organizations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lovablelabs%2Fdocs&utm_source=github&utm_medium=referral)<sup> for b0136012ecd57ce4b72c7ea0796a87dbc8dc50c0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->