### PR TITLE
Add info + disclaimer on chat modes experiment

### DIFF
--- a/tips-tricks/prompting.mdx
+++ b/tips-tricks/prompting.mdx
@@ -353,20 +353,19 @@ Review this GitHub project structure. Evaluate the flow, dependencies, and sugge
   ```
 </Note>
 
-### **"Chat-Only Mode" Trick**
 
-When brainstorming without making code changes:
+### Experiment with chat modes
 
-<Note>
-  ```
-  "I’m not sure about this feature. Should I refactor it?"
-  Wrap comments in quotes like:
-  "Refactor this? What’s the best approach?"
-  ```
-</Note>
+Chat modes are an experimental feature which allow you to switch how you interact with Lovable. We shipped Chat modes with:
 
-This prevents accidental code execution, allowing for ideation.
+1. Default: Chat and make edits to your project.
+2. Chat only: Chat without making edits to your project.
+
+We may ship extra chat modes in the future, or remove them altogether as we experiment with different ways of interacting with Lovable.
+
 
 ## Conclusion
 
 Prompting in Lovable becomes more powerful when you combine strategies like incremental prompting, contextual instructions, and the newly introduced **Lovable Prompts**. Experiment, iterate, and leverage these practices to streamline your workflows, debug effectively, and build robust applications.
+
+<br />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds documentation on experimental chat modes in `prompting.mdx`, detailing current modes and potential future changes.
> 
>   - **Documentation**:
>     - Adds "Experiment with chat modes" section in `prompting.mdx`.
>     - Describes two chat modes: "Default" (chat and edit) and "Chat only" (chat without edits).
>     - Mentions potential future changes to chat modes as part of ongoing experiments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lovablelabs%2Fdocs&utm_source=github&utm_medium=referral)<sup> for ab044f6e8f6e5634f1e1fab365e285cd638147ca. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->